### PR TITLE
基数排序Java代码初始化桶问题

### DIFF
--- a/10.radixSort.md
+++ b/10.radixSort.md
@@ -134,10 +134,10 @@ public class RadixSort implements IArraySort {
 
         for (int i = 0; i < maxDigit; i++, dev *= 10, mod *= 10) {
             // 考虑负数的情况，这里扩展一倍队列数，其中 [0-9]对应负数，[10-19]对应正数 (bucket + 10)
-            int[][] counter = new int[mod * 2][0];
+            int[][] counter = new int[20][0];
 
             for (int j = 0; j < arr.length; j++) {
-                int bucket = ((arr[j] % mod) / dev) + mod;
+                int bucket = ((arr[j] % mod) / dev) + 10;
                 counter[bucket] = arrayAppend(counter[bucket], arr[j]);
             }
 


### PR DESCRIPTION
mod每次循环会乘10，导致counter每次初始化行都扩大十倍。但这是不必要的，counter的行能包含[-9,9]就可以了。